### PR TITLE
Fix create-preservation not validating response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.10]
+
+- Fix create-preservation script that was failing to parse the response when validating found/not-found users
+
 ## [1.0.9]
 
 - Replicate new structure of developers.onna.com for tutorial files

--- a/tutorials/datasources/create-preservation/create-preservation.py
+++ b/tutorials/datasources/create-preservation/create-preservation.py
@@ -123,14 +123,12 @@ def verification_request(emails, token, account_url):
 
 
 def parse_response(response):
-
     found_emails = []
-    not_found_emails = []
-    for account in response:
-        if account.get("found") is True:
-            found_emails.append(account.get("email"))
-        else:
-            not_found_emails.append(account.get("email"))
+    for account in response.get("found", []):
+        for source_account in account.get("source_accounts", []):
+            found_emails.append(source_account.get("email"))
+
+    not_found_emails = [email for email in response.get("not_found")]
 
     return found_emails, not_found_emails
 


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description

Fix parse_response, due to a change in the api response structure, this was failing to parse correctly

# ⚡ Priority

Define the ETA

- [ ] High (As soon as possible)
- [ ] Medium (2 days)
- [X] Low (5 days)
